### PR TITLE
Use elixir_uuid

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Riverside.Mixfile do
       :poison,
       :prometheus_plugs,
       :secure_random,
-      :uuid
+      :elixir_uuid
       ]]
   end
 
@@ -36,7 +36,7 @@ defmodule Riverside.Mixfile do
      {:secure_random, "~> 0.5.1"},
      {:socket, "~> 0.3.12"},
      {:the_end, "~> 1.1.0"},
-     {:uuid, "~> 1.1"}
+     {:elixir_uuid, "~> 1.2"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -4,6 +4,7 @@
   "cowlib": {:hex, :cowlib, "2.3.0", "bbd58ef537904e4f7c1dd62e6aa8bc831c8183ce4efa9bd1150164fe15be4caa", [:rebar3], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], []},
   "ebus": {:hex, :erlbus, "0.2.1", "7d976888a8f8f3583200d31494d4629d9796d5790ecf14a5da6fbb9253106607", [:make, :rebar3], []},
+  "elixir_uuid": {:hex, :elixir_uuid, "1.2.0", "ff26e938f95830b1db152cb6e594d711c10c02c6391236900ddd070a6b01271d", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.16.4", "4bf6b82d4f0a643b500366ed7134896e8cccdbab4d1a7a35524951b25b1ec9f0", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
   "gproc": {:hex, :gproc, "0.5.0", "2df2d886f8f8a7b81a4b04aa17972b5965bbc5bf0100ea6d8e8ac6a0e7389afe", [:rebar], []},
   "graceful_stopper": {:git, "https://github.com/lyokato/graceful_stopper.git", "a7673a622a6ce2787ff56bd618593cf464b19768", [tag: "0.1.1"]},
@@ -18,5 +19,4 @@
   "secure_random": {:hex, :secure_random, "0.5.1", "c5532b37c89d175c328f5196a0c2a5680b15ebce3e654da37129a9fe40ebf51b", [:mix], []},
   "socket": {:hex, :socket, "0.3.12", "4a6543815136503fee67eff0932da1742fad83f84c49130c854114153cc549a6", [:mix], []},
   "the_end": {:hex, :the_end, "1.1.0", "cd11af29051d8823b2e4d0109aa0bf0f08a00ce60ca36080ad2014e11e7f9d52", [:mix], [], "hexpm"},
-  "uuid": {:hex, :uuid, "1.1.7", "007afd58273bc0bc7f849c3bdc763e2f8124e83b957e515368c498b641f7ab69", [:mix], []},
 }


### PR DESCRIPTION
Should fix this error:

```
Unchecked dependencies for environment prod:
* uuid (Hex package)
  could not find an app file at "_build/prod/lib/uuid/ebin/uuid.app". This may happen if the dependency was not yet compiled, or you specified the wrong application name in your deps, or the dependency indeed has no app file (then you can pass app: false as option)
```